### PR TITLE
fix: Make deployment name configurable

### DIFF
--- a/charts/aws-eks-asg-rolling-update-handler/Chart.yaml
+++ b/charts/aws-eks-asg-rolling-update-handler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-eks-asg-rolling-update-handler
-version: 1.2.6
+version: 1.2.7
 description: Handles rolling upgrades for AWS ASGs for EKS by replacing outdated nodes by new nodes.
 home: https://github.com/TwiN/aws-eks-asg-rolling-update-handler
 maintainers:

--- a/charts/aws-eks-asg-rolling-update-handler/templates/deployment.yaml
+++ b/charts/aws-eks-asg-rolling-update-handler/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aws-eks-asg-rolling-update-handler
+  name:  {{ template "aws-eks-asg-rolling-update-handler.name" . }}
   namespace: {{ template "aws-eks-asg-rolling-update-handler.namespace" . }}
   labels:
 {{ include "aws-eks-asg-rolling-update-handler.labels" . | indent 4 }}


### PR DESCRIPTION
Signed-off-by: Amir <amirghotbi@gmail.com>

<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
I would like to install multi deployments with different configurations. In this case we can use different deployment's name for each of those configurations.

the name of the deployment object will be the same as the container name.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Added the documentation in `README.md`, if applicable.
