### PR TITLE
feat(aws-eks-asg-rolling-update-handler): Add option to set custom security context

### DIFF
--- a/charts/aws-eks-asg-rolling-update-handler/Chart.yaml
+++ b/charts/aws-eks-asg-rolling-update-handler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-eks-asg-rolling-update-handler
-version: 1.4.0
+version: 1.4.1
 description: Handles rolling upgrades for AWS ASGs for EKS by replacing outdated nodes by new nodes.
 home: https://github.com/TwiN/aws-eks-asg-rolling-update-handler
 maintainers:

--- a/charts/aws-eks-asg-rolling-update-handler/Chart.yaml
+++ b/charts/aws-eks-asg-rolling-update-handler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-eks-asg-rolling-update-handler
-version: 1.4.1
+version: 1.5.0
 description: Handles rolling upgrades for AWS ASGs for EKS by replacing outdated nodes by new nodes.
 home: https://github.com/TwiN/aws-eks-asg-rolling-update-handler
 maintainers:

--- a/charts/aws-eks-asg-rolling-update-handler/README.md
+++ b/charts/aws-eks-asg-rolling-update-handler/README.md
@@ -12,3 +12,5 @@ The following table lists the configurable parameters of the aws-eks-asg-rolling
 | resources | CPU/memory resource requests/limits | no | `{}` |
 | podAnnotations | Annotations to add to the aws-eks-asg-rolling-update-handler pod configuration | no | `{}` |
 | podLabels | Labels to add to the aws-eks-asg-rolling-update-handler pod configuration | no | `{}` |
+| securityContext | Pod security context | no | `{}` |
+| containerSecurityContext | Container security context | no | `{}` |

--- a/charts/aws-eks-asg-rolling-update-handler/templates/deployment.yaml
+++ b/charts/aws-eks-asg-rolling-update-handler/templates/deployment.yaml
@@ -17,12 +17,16 @@ spec:
 {{ include "aws-eks-asg-rolling-update-handler.labels" . | indent 8 }}
       {{- with .Values.podLabels }}
       {{- toYaml . | nindent 8 }}
-      {{- end }}    
+      {{- end }}
       annotations:
       {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+        {{ toYaml .Values.securityContext | nindent 8 | trim }}
+      {{- end }}
       automountServiceAccountToken: true
       serviceAccountName: {{ template "aws-eks-asg-rolling-update-handler.serviceAccountName" . }}
       restartPolicy: Always
@@ -31,6 +35,10 @@ spec:
         - name: {{ template "aws-eks-asg-rolling-update-handler.name" . }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext:
+            {{ toYaml .Values.containerSecurityContext | nindent 12 | trim }}
+          {{- end }}
           env:
 {{- toYaml .Values.environmentVars | nindent 12 }}
 {{- with .Values.resources }}

--- a/charts/aws-eks-asg-rolling-update-handler/values.yaml
+++ b/charts/aws-eks-asg-rolling-update-handler/values.yaml
@@ -37,3 +37,15 @@ serviceAccount:
   create: true
   #name: aws-eks-asg-rolling-update-handler
   annotations: {}
+
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1001
+  # seccompProfile:
+#  type: RuntimeDefault
+
+containerSecurityContext: {}
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #  drop:
+#    - ALL


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

This PR allows a user to set a custom security context. Setting a security context is required if the target namespace of the deployment has a pod security standard  (https://kubernetes.io/docs/concepts/security/pod-security-standards/) set.

I think the rolling update handler can be run under the restricted pod security standard, however I didn't want to change the default behaviour of the chart so I commented the restricted settings in the `values.yaml` out but if a user wants to set a security context, they can do so now.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
