### PR TITLE
feat:(k8s-ttl-controller) Exposing resources to the values file

### DIFF
--- a/charts/k8s-ttl-controller/templates/deployment.yaml
+++ b/charts/k8s-ttl-controller/templates/deployment.yaml
@@ -23,3 +23,6 @@ spec:
         - name: k8s-ttl-controller
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.resources }}
+          resources: {{ toYaml .Values.resources | nindent12 }}
+          {{- end }}

--- a/charts/k8s-ttl-controller/values.yaml
+++ b/charts/k8s-ttl-controller/values.yaml
@@ -3,13 +3,16 @@ image:
   tag: v1.2.0
   pullPolicy: IfNotPresent
 
-resources:
-  requests:
-    cpu: 16m
-    memory: 128Mi
-  limits:
-    cpu: 32m
-    memory: 256Mi
+# By default no resource limit and requests will be set. 
+# However you can set this by uncommenting the following configuration.
+ 
+# resources:
+#   requests:
+#     cpu: 16m
+#     memory: 128Mi
+#   limits:
+#     cpu: 32m
+#     memory: 256Mi
 
 # By default, a ServiceAccount, ClusterRole and ClusterRoleBinding
 # will be created with complete access. You can however opt to

--- a/charts/k8s-ttl-controller/values.yaml
+++ b/charts/k8s-ttl-controller/values.yaml
@@ -3,6 +3,14 @@ image:
   tag: v1.2.0
   pullPolicy: IfNotPresent
 
+resources:
+  requests:
+    cpu: 16m
+    memory: 128Mi
+  limits:
+    cpu: 32m
+    memory: 256Mi
+
 # By default, a ServiceAccount, ClusterRole and ClusterRoleBinding
 # will be created with complete access. You can however opt to
 # create your own ServiceAccount by setting serviceAccount.create

--- a/charts/k8s-ttl-controller/values.yaml
+++ b/charts/k8s-ttl-controller/values.yaml
@@ -5,7 +5,6 @@ image:
 
 # By default no resource limit and requests will be set. 
 # However you can set this by uncommenting the following configuration.
- 
 # resources:
 #   requests:
 #     cpu: 16m

--- a/charts/k8s-ttl-controller/values.yaml
+++ b/charts/k8s-ttl-controller/values.yaml
@@ -5,13 +5,13 @@ image:
 
 # By default no resource limit and requests will be set. 
 # However you can set this by uncommenting the following configuration.
-# resources:
-#   requests:
-#     cpu: 16m
-#     memory: 128Mi
-#   limits:
-#     cpu: 32m
-#     memory: 256Mi
+#resources:
+#  requests:
+#    cpu: 16m
+#    memory: 128Mi
+#  limits:
+#    cpu: 32m
+#    memory: 256Mi
 
 # By default, a ServiceAccount, ClusterRole and ClusterRoleBinding
 # will be created with complete access. You can however opt to


### PR DESCRIPTION
## Summary
Fixes #10

The issue makes it so that the resources property can be set from the helmchart values.yaml file.

## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
