### PR TITLE
Take gatus chart templates from minicloudlabs

### DIFF
--- a/charts/gatus/Chart.yaml
+++ b/charts/gatus/Chart.yaml
@@ -1,7 +1,15 @@
 apiVersion: v2
 name: gatus
+description: Automated service health dashboard
+icon: https://raw.githubusercontent.com/TwiN/gatus/a1c8422c2ff2b9d0a6f184c99e4dc728d3f2cd75/web/static/logo-192x192.png
 version: 0.1.4
-description: Deploys a Gatus instance
+appVersion: v5.11.0
+type: application
+engine: gotpl
 home: https://github.com/TwiN/gatus
+sources:
+  - https://github.com/TwiN/helm-charts
+  - https://github.com/TwiN/gatus
 maintainers:
   - name: TwiN
+keywords: ['gatus', 'healthcheck', 'uptime', 'monitoring']

--- a/charts/gatus/Chart.yaml
+++ b/charts/gatus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gatus
 description: Automated service health dashboard
 icon: https://raw.githubusercontent.com/TwiN/gatus/a1c8422c2ff2b9d0a6f184c99e4dc728d3f2cd75/web/static/logo-192x192.png
-version: 0.1.4
+version: 1.0.0
 appVersion: v5.11.0
 type: application
 engine: gotpl

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -29,19 +29,6 @@ helm delete --purge [RELEASE_NAME]
 This removes all the Kubernetes components associated with the chart and deletes the release.
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading an existing Release to a new major version
-
-### To 3.0.0
-
-This version bumps Gatus image from 4.4.0 to 5.1.0, so your config from v4 could potentially have incompatibilities with v5.
-Please check corresponding Gatus release changelog: [v5.0.0](https://github.com/TwiN/gatus/releases/tag/v5.0.0) and
-[v5.1.0](https://github.com/TwiN/gatus/releases/tag/v5.1.0).
-
-### To 2.0.0
-
-This version requires Helm >= 3
-Gatus version is upgraded from 2 to 3. Gatus 3 deprecates `memory` type of storage, supports `sqlite` and `postgres`.
-`storage` is not part of `persistence` anymore and is part of `config` now. Check the example below.
 
 ## Configuration
 

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -2,25 +2,12 @@
 
 > Installs the automated service health dashboard [Gatus](https://github.com/TwiN/gatus)
 
+
 ## Get Repo Info
 
 ```console
 helm repo add twin https://twin.github.io/helm-charts
 helm repo update
-```
-
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Chart
-
-```console
-helm install --name [RELEASE_NAME] twin/gatus
-```
-
-_See [configuration](#configuration) below._
-_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
-
-## Uninstall Chart
 
 ```console
 helm delete --purge [RELEASE_NAME]

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -1,1 +1,156 @@
-You can find an alternative to this chart here: https://github.com/minicloudlabs/helm-charts/tree/main/charts/gatus
+# Gatus Helm Chart
+
+> Installs the automated service health dashboard [Gatus](https://github.com/TwiN/gatus)
+
+## Get Repo Info
+
+```console
+helm repo add twin https://twin.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Install Chart
+
+```console
+helm install --name [RELEASE_NAME] twin/gatus
+```
+
+_See [configuration](#configuration) below._
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading an existing Release to a new major version
+
+### To 3.0.0
+
+This version bumps Gatus image from 4.4.0 to 5.1.0, so your config from v4 could potentially have incompatibilities with v5.
+Please check corresponding Gatus release changelog: [v5.0.0](https://github.com/TwiN/gatus/releases/tag/v5.0.0) and
+[v5.1.0](https://github.com/TwiN/gatus/releases/tag/v5.1.0).
+
+### To 2.0.0
+
+This version requires Helm >= 3
+Gatus version is upgraded from 2 to 3. Gatus 3 deprecates `memory` type of storage, supports `sqlite` and `postgres`.
+`storage` is not part of `persistence` anymore and is part of `config` now. Check the example below.
+
+## Configuration
+
+| Parameter                                 | Description                                     | Default                             |
+|-------------------------------------------|-------------------------------------------------|-------------------------------------|
+| `deployment.strategy`                     | Deployment strategy                             | `RollingUpdate`                     |
+| `deployment.annotateConfigChecksum`       | Restart pod when config changed                 | `true`                              |
+| `readinessProbe.enabled`                  | Enable readiness probe                          | `true`                              |
+| `livenessProbe.enabled`                   | Enable liveness probe                           | `true`                              |
+| `image.repository`                        | Image repository                                | `twinproduction/gatus`              |
+| `image.tag`                               | Overrides the Gatus image tag                   | ``                                  |
+| `image.sha`                               | Image sha                                       | ``                                  |
+| `image.pullPolicy`                        | Image pull policy                               | `IfNotPresent`                      |
+| `image.pullSecrets`                       | Image pull secrets                              | `{}`                                |
+| `hostNetwork.enabled`                     | Enable host network mode                        | `false`                             |
+| `annotations`                             | Deployment annotations                          | `{}`                                |
+| `labels`                                  | Deployment labels                               | `{}`                                |
+| `podAnnotations`                          | Pod annotations                                 | `{}`                                |
+| `podLabels`                               | Pod labels                                      | `{}`                                |
+| `extraLabels`                             | Extra labels for all manifests                  | `{}`                                |
+| `serviceAccount.create`                   | Create service account                          | `false`                             |
+| `serviceAccount.name`                     | Service account name to use                     | ``                                  |
+| `serviceAccount.annotations`              | ServiceAccount annotations                      | `{}`                                |
+| `serviceAccount.autoMount`                | Automount the service account token in the pod  | `false`                             |
+| `podSecurityContext.fsGroup`              | Pod volume's ownership GID                      | `65534`                             |
+| `securityContext.runAsNonRoot`            | Container runs as a non-root user               | `true`                              |
+| `securityContext.runAsUser`               | Container processes' UID to run the entrypoint  | `65534`                             |
+| `securityContext.runAsGroup`              | Container processes' GID to run the entrypoint  | `65534`                             |
+| `securityContext.readOnlyRootFilesystem`  | Container's root filesystem is read-only        | `true`                              |
+| `service.type`                            | Type of service                                 | `ClusterIP`                         |
+| `service.port`                            | Port for kubernetes service                     | `80`                                |
+| `service.targetPort`                      | Port for container                              | `8080`                              |
+| `service.annotations`                     | Service annotations                             | `{}`                                |
+| `service.labels`                          | Custom labels                                   | `{}`                                |
+| `ingress.enabled`                         | Enables Ingress                                 | `false`                             |
+| `ingress.ingressClassName`                | Ingress ClassName (for k8s 1.18+)               | ``                                  |
+| `ingress.name`                            | Ingress name                                    | ``                                  |
+| `ingress.annotations`                     | Ingress annotations (values are templated)      | `{}`                                |
+| `ingress.labels`                          | Custom labels                                   | `{}`                                |
+| `ingress.path`                            | Ingress accepted path                           | `/`                                 |
+| `ingress.pathType`                        | Ingress type of path                            | `Prefix`                            |
+| `ingress.extraPaths`                      | Ingress extra paths to prepend to every host    | `[]`                                |
+| `ingress.hosts`                           | Ingress accepted hostnames                      | `["chart-example.local"]`           |
+| `ingress.tls`                             | Ingress TLS configuration                       | `[]`                                |
+| `env`                                     | Extra environment variables passed to pods      | `{}`                                |
+| `sidecarContainers`                       | Sidecar containers in the pod                   | `{}`                                |
+| `extraVolumeMounts`                       | Extra volume mounts                             | `[]`                                |
+| `secrets`                                 | Include secret's content in pod environment     | `false`                             |
+| `resources`                               | CPU/Memory resource requests/limits             | `{}`                                |
+| `nodeSelector`                            | Node labels for pod assignment                  | `{}`                                |
+| `tolerations`                             | Tolerations for pod assignment                  | `[]`                                |
+| `extraInitContainers`                     | Init containers to add to the gatus pod         | `[]`                                |
+| `persistence.enabled`                     | Use persistent volume to store data             | `false`                             |
+| `persistence.size`                        | Size of persistent volume claim                 | `200Mi`                             |
+| `persistence.mounthPath`                  | Persistent data volume's mount path             | `/data`                             |
+| `persistence.subPath`                     | Mount a sub dir of the persistent volume        | `nil`                               |
+| `persistence.accessModes`                 | Persistence access modes                        | `[ReadWriteOnce]`                   |
+| `persistence.finalizers`                  | PersistentVolumeClaim finalizers                | `["kubernetes.io/pvc-protection"]`  |
+| `persistence.annotations`                 | PersistentVolumeClaim annotations               | `{}`                                |
+| `persistence.selectorLabels`              | PersistentVolumeClaim selector labels           | `{}`                                |
+| `persistence.existingClaim`               | Use an existing PVC to persist data             | `nil`                               |
+| `persistence.storageClassName`            | Type of persistent volume claim                 | `nil`                               |
+| `serviceMonitor.enabled`                  | Use servicemonitor from prometheus operator     | `false`                             |
+| `serviceMonitor.namespace`                | Namespace this servicemonitor is installed in   | ``                                  |
+| `serviceMonitor.interval`                 | How frequently Prometheus should scrape         | `1m`                                |
+| `serviceMonitor.path`                     | Path to scrape                                  | `/metrics`                          |
+| `serviceMonitor.scheme`                   | Scheme to use for metrics scraping              | `http`                              |
+| `serviceMonitor.tlsConfig`                | TLS configuration block for the endpoint        | `{}`                                |
+| `serviceMonitor.labels`                   | Labels for the servicemonitor object            | `{}`                                |
+| `serviceMonitor.scrapeTimeout`            | Timeout after which the scrape is ended         | `30s`                               |
+| `serviceMonitor.relabelings`              | RelabelConfigs for samples before ingestion     | `[]`                                |
+| `networkPolicy.enabled`                   | Enable creation of NetworkPolicy resources      | `false`                             |
+| `networkPolicy.ingress.selectors`         | List of Ingress Rule selectors                  | `[]`                                |
+| `config`                                  | [Gatus configuration][gatus-config]             | `{}`                                |
+
+_See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)._
+
+To see all configurable options with detailed comments, visit the chart's [values.yaml](./gatus/values.yaml), or run
+
+```console
+helm inspect values twin/gatus
+```
+
+### `helmfile.yaml` example
+
+```yaml
+---
+repositories:
+  - name: twin
+    url: https://twin.github.io/helm-charts
+
+releases:
+  - name: gatus
+    namespace: gatus
+    chart: twin/gatus
+    version: 1.0.0
+    values:
+      - persistence:
+          enabled: true
+      - config:
+          storage:
+            type: sqlite
+            path: /data/data.db
+          endpoints:
+            - name: Example
+              url: https://example.com
+              conditions:
+                - '[STATUS] == 200'
+```
+
+
+[gatus-config]: https://github.com/TwiN/gatus#configuration

--- a/charts/gatus/templates/_helpers.tpl
+++ b/charts/gatus/templates/_helpers.tpl
@@ -1,36 +1,139 @@
-{{/* Name */}}
-{{- define "gatus.name" }}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{ end -}}
+{{/*
+Chart name and version as used by the chart label
+Usage: {{ include "names.chart" . }}
+*/}}
+{{- define "names.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+Name of the chart, truncated at 63 chars
+Usage: {{ include "names.name" . }}
 */}}
-{{- define "gatus.fullname" -}}
+{{- define "names.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name, truncated at 63 chars
+Usage: {{ include "names.fullname" . }}
+*/}}
+{{- define "names.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 
-{{/* Common labels */}}
-{{- define "gatus.labels" -}}
-app.kubernetes.io/name: {{ include "gatus.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{/*
+Namespace of the chart, truncated at 63 chars
+Usage: {{ include "names.namespace" . }}
+*/}}
+{{- define "names.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/* Match labels */}}
-{{- define "gatus.matchLabels" -}}
-app.kubernetes.io/name: {{ include "gatus.name" . }}
+{{/*
+Name of the ServiceAccount
+Usage: {{ include "names.serviceAccountName" . }}
+*/}}
+{{- define "names.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create -}}
+    {{ default (include "names.fullname" .) .Values.serviceAccount.name }}
+  {{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Chart selector labels
+Usage: {{ include "labels.selectorLabels" . }}
+*/}}
+{{- define "labels.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "names.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Chart base labels
+Usage: {{ include "labels.baseLabels" . }}
+*/}}
+{{- define "labels.baseLabels" -}}
+helm.sh/chart: {{ include "names.chart" . }}
+{{ include "labels.selectorLabels" . }}
+{{- if or .Chart.AppVersion .Values.image.tag }}
+app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.image.tag "" | default .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Appropriate ingress apiVersion for current KubeVersion
+Usage: {{ include "ingress.apiVersion" . }}
+*/}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Check whether ingress api version is stable
+Usage: {{ include "ingress.isStable" . }}
+*/}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Check whether ingress supports class names
+Usage: {{ include "ingress.supportsIngressClassName" . }}
+*/}}
+{{- define "ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}
+
+{{/*
+Check whether ingress supports path types
+Usage: {{ include "ingress.supportsPathType" . }}
+*/}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}
+
+{{/*
+Generate backend entry that is compatible with all Kubernetes versions
+Usage: {{ include "ingress.backend" (dict "serviceName" "backendName" "servicePort" "backendPort" "context" $) }}
+Params:
+  - serviceName - String. Name of an existing service backend
+  - servicePort - String/Int. Port name (or number) of the service
+  - context - Dict. The context for the template evaluation
+*/}}
+{{- define "ingress.backend" -}}
+{{- if eq (include "ingress.isStable" .context) "true" -}}
+service:
+  name: {{ .serviceName }}
+  port:
+    {{- if typeIs "string" .servicePort }}
+    name: {{ .servicePort }}
+    {{- else if or (typeIs "int" .servicePort) (typeIs "float64" .servicePort) }}
+    number: {{ .servicePort | int }}
+    {{- end }}
+{{- else -}}
+serviceName: {{ .serviceName }}
+servicePort: {{ .servicePort }}
+{{- end -}}
 {{- end -}}

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -1,0 +1,124 @@
+{{- define "gatus.pod" -}}
+{{- if .Values.hostNetwork.enabled }}
+hostNetwork: true
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+imagePullSecrets:
+  {{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+  {{- end }}
+{{- end }}
+serviceAccountName: {{ include "names.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.serviceAccount.autoMount }}
+securityContext:
+  {{- toYaml .Values.podSecurityContext | nindent 2 }}
+{{- if .Values.extraInitContainers }}
+initContainers:
+{{- toYaml .Values.extraInitContainers | nindent 2 }}
+{{- end }}
+containers:
+{{- if .Values.sidecarContainers }}
+  {{- range $name, $spec :=  .Values.sidecarContainers }}
+  - name: {{ $name }}
+    {{- if not $spec.securityContext }}
+    securityContext:
+      {{- toYaml $.Values.securityContext | nindent 6 }}
+    {{- end }}
+    {{- toYaml $spec | nindent 4 }}
+  {{- end }}
+{{- end }}
+  - name: {{ .Chart.Name }}
+    securityContext:
+      {{- toYaml .Values.securityContext | nindent 6 }}
+    {{- if .Values.image.sha }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
+    {{- else }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+    {{- end }}
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    ports:
+      - name: http
+        containerPort: {{ .Values.service.targetPort }}
+        protocol: TCP
+    {{- if .Values.env }}
+    env:
+    {{- range $key, $value := .Values.env }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
+    {{- end }}
+    {{- end }}
+    envFrom:
+      - configMapRef:
+          name: {{ include "names.fullname" . }}
+      {{- if .Values.secrets }}
+      - secretRef:
+          name: {{ include "names.fullname" . }}
+      {{- end }}
+    {{- if .Values.readinessProbe.enabled }}
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: http
+    {{- end }}
+    {{- if .Values.livenessProbe.enabled }}
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: http
+    {{- end }}
+    resources:
+      {{- toYaml .Values.resources | nindent 6 }}
+    volumeMounts:
+      - name: {{ include "names.fullname" . }}-config
+        mountPath: /config
+        readOnly: true
+      {{- if .Values.persistence.enabled }}
+      - name: {{ include "names.fullname" . }}-data
+        mountPath: {{ .Values.persistence.mountPath }}
+        {{- if .Values.persistence.subPath }}
+        subPath: {{ .Values.persistence.subPath }}
+        {{- end }}
+      {{- end }}
+    {{- range .Values.extraVolumeMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+        subPath: {{ .subPath | default "" }}
+        readOnly: {{ .readOnly }}
+    {{- end }}
+volumes:
+  - name: {{ include "names.fullname" . }}-config
+    configMap:
+      name: {{ include "names.fullname" . }}
+  {{- if .Values.persistence.enabled }}
+  - name: {{ include "names.fullname" . }}-data
+    persistentVolumeClaim:
+      claimName: {{ .Values.persistence.existingClaim | default (include "names.fullname" .) }}
+  {{- end }}
+{{- range .Values.extraVolumeMounts }}
+  - name: {{ .name }}
+    {{- if .existingClaim }}
+    persistentVolumeClaim:
+      claimName: {{ .existingClaim }}
+    {{- else if .hostPath }}
+    hostPath:
+      path: {{ .hostPath }}
+      type: {{ .hostPathType | default "" }}
+    {{- else if .existingConfigMap }}
+    configMap:
+      name: {{ .existingConfigMap }}
+    {{- else if .existingSecret }}
+    secret:
+      secretName: {{ .existingSecret }}
+    {{- else }}
+    emptyDir: {}
+    {{- end }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/gatus/templates/config-map.yaml
+++ b/charts/gatus/templates/config-map.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "gatus.fullname" . }}
-  labels: {{- include "gatus.labels" . | nindent 4 }}
-data:
-  config.yaml: |
-    {{- toYaml .Values.config | trimPrefix "|" | nindent 4  }}

--- a/charts/gatus/templates/configmap.yaml
+++ b/charts/gatus/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "names.fullname" . }}
+  namespace: {{ include "names.namespace" . }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/gatus/templates/deployment.yaml
+++ b/charts/gatus/templates/deployment.yaml
@@ -1,54 +1,37 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "gatus.fullname" . }}
-  labels: {{- include "gatus.labels" . | nindent 4 }}
+  name: {{ include "names.fullname" . }}
+  namespace: {{ include "names.namespace" . }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: 1
   selector:
-    matchLabels: {{- include "gatus.matchLabels" . | nindent 6 }}
+    matchLabels:
+      {{- include "labels.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.deployment.strategy }}
   template:
     metadata:
-      name: {{ template "gatus.fullname" . }}
-      labels: {{- include "gatus.labels" . | nindent 8 }}
+      labels:
+        {{- include "labels.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.deployment.annotateConfigChecksum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}
-      terminationGracePeriodSeconds: 5
-      containers:
-        - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          name: gatus
-          ports:
-            - containerPort: 8080
-              name: http
-              protocol: TCP
-          resources:
-            limits:
-              cpu: 250m
-              memory: 100M
-            requests:
-              cpu: 50m
-              memory: 30M
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 3
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 5
-          volumeMounts:
-            - mountPath: /config
-              name: config
-      volumes:
-        - configMap:
-            name: {{ template "gatus.fullname" . }}
-          name: config
+      {{- include "gatus.pod" . | nindent 6 }}

--- a/charts/gatus/templates/ingress.yaml
+++ b/charts/gatus/templates/ingress.yaml
@@ -1,38 +1,60 @@
-{{- if .Values.ingress.enabled }}
-{{- $fullname := include "gatus.fullname" . -}}
-apiVersion: networking.k8s.io/v1
+{{- if .Values.ingress.enabled -}}
+  {{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
+  {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+  {{- $fullName := include "names.fullname" . -}}
+  {{- $servicePort := .Values.service.port -}}
+  {{- $ingressPath := .Values.ingress.path -}}
+  {{- $ingressPathType := .Values.ingress.pathType -}}
+  {{- $extraPaths := .Values.ingress.extraPaths -}}
+---
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ template "gatus.fullname" . }}
-  labels: {{- include "gatus.labels" . | nindent 4 }}
+  name: {{ .Values.ingress.name | default $fullName }}
+  namespace: {{ include "names.namespace" . }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
-  annotations: {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
-  {{- end }}
-  rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $fullname }}
-                port:
-                  number: 8080
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}
   {{- end }}
+spec:
+  {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end -}}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ tpl (toYaml .Values.ingress.tls) $ | indent 4 }}
+{{- end }}
+  rules:
+  {{- if .Values.ingress.hosts  }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ tpl . $}}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
+            backend: {{- include "ingress.backend" (dict "serviceName" $fullName "servicePort" $servicePort "context" $)  | nindent 14 }}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+  {{- end }}
+  {{- else }}
+    - http:
+        paths:
+          - backend: {{- include "ingress.backend" (dict "serviceName" $fullName "servicePort" $servicePort "context" $)  | nindent 14 }}
+            {{- if $ingressPath }}
+            path: {{ $ingressPath }}
+            {{- end }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
+  {{- end -}}
 {{- end }}

--- a/charts/gatus/templates/networkpolicy.yaml
+++ b/charts/gatus/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "names.fullname" . }}
+  namespace: {{ include "names.namespace" . }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+    {{- include "labels.selectorLabels" . | nindent 6 }}
+  {{- if .Values.networkPolicy.ingress.selectors }}
+  ingress:
+    - from:
+      {{-  toYaml .Values.networkPolicy.ingress.selectors | nindent 6 }}
+    - ports:
+      - port: {{ .Values.service.targetPort }}
+  {{- end }}
+{{- end }}

--- a/charts/gatus/templates/pvc.yaml
+++ b/charts/gatus/templates/pvc.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim)}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "names.fullname" . }}
+  namespace: {{ include "names.namespace" . }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.persistence.finalizers }}
+  finalizers:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end -}}
+  {{- with .Values.persistence.selectorLabels }}
+  selector:
+    matchLabels:
+{{ toYaml . | indent 6 }}
+  {{- end }}
+{{- end -}}

--- a/charts/gatus/templates/service-account.yaml
+++ b/charts/gatus/templates/service-account.yaml
@@ -1,7 +1,0 @@
-{{- if .Values.serviceAccount.create }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Values.serviceAccount.name }}
-  labels: {{- include "gatus.labels" . | nindent 4 }}
-{{- end -}}

--- a/charts/gatus/templates/service.yaml
+++ b/charts/gatus/templates/service.yaml
@@ -1,12 +1,23 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "gatus.fullname" . }}
-  labels: {{- include "gatus.labels" . | nindent 4 }}
+  name: {{ include "names.fullname" . }}
+  namespace: {{ include "names.namespace" . }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
     - name: http
-      port: 8080
+      port: {{ .Values.service.port }}
+      targetPort: http
       protocol: TCP
-      targetPort: 8080
-  selector: {{- include "gatus.matchLabels" . | nindent 4 }}
+  selector:
+    {{- include "labels.selectorLabels" . | nindent 4 }}

--- a/charts/gatus/templates/serviceaccount.yaml
+++ b/charts/gatus/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ include "names.serviceAccountName" . }}
+  namespace: {{ include "names.namespace" . }}
+{{- end }}

--- a/charts/gatus/templates/servicemonitor.yaml
+++ b/charts/gatus/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "names.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ include "names.namespace" . }}
+  {{- end }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: {{ .Values.service.portName }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    honorLabels: true
+    path: {{ .Values.serviceMonitor.path }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+    {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "labels.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -1,28 +1,194 @@
+# See `kubectl explain deployment.spec.strategy` for more
+# ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+deployment:
+  strategy: RollingUpdate
+  annotateConfigChecksum: true
+
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
+readinessProbe:
+  enabled: true
+
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request
+livenessProbe:
+  enabled: true
+
 image:
   repository: twinproduction/gatus
-  tag: v5.4.0
+  # Overrides the Gatus image tag whose default is the chart appVersion
+  tag: ""
+  sha: ""
   pullPolicy: IfNotPresent
+
+  # Optionally specify an array of imagePullSecrets.
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+hostNetwork:
+  enabled: false
+
+# Additional deployment annotations
+annotations: {}
+
+# Additional deployment labels
+labels: {}
+
+podAnnotations: {}
+
+podLabels: {}
+
+# Apply extra labels to common labels
+extraLabels: {}
+
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+  autoMount: false
+
+podSecurityContext:
+  fsGroup: 65534
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  readOnlyRootFilesystem: true
+
+# Expose the gatus service to be accessed from outside the cluster (LoadBalancer service)
+# or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+# ref: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+  annotations: {}
+  labels: {}
 
 ingress:
   enabled: false
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-  #ingressClassName: nginx
+  # ingressClassName: nginx
   # Values can be templated
   annotations: {}
-  #  kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   labels: {}
   path: /
+  # pathType is only for k8s >= 1.1=
+  pathType: Prefix
+  extraPaths: []
   hosts:
-    - chart-example.local
+    - gatus.local
+  # Extra paths to prepend to every host configuration, requires `ingress.hosts` to have one or more host entries.
+  # Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions).
   tls: []
-  #  - secretName: chart-example.local-tls
+  #  - secretName: gatus-tls
   #    hosts:
-  #      - chart-example.local
+  #      - gatus.local
 
-serviceAccount:
-  create: true
-  name: gatus
+# Extra environment variables that will be pass onto deployment pods
+# Expects key: value
+env: {}
+  # GATUS_CONFIG_PATH: config/config.yaml
 
-# See https://github.com/TwiN/gatus#configuration
-config: {}
+# Sidecar containers in the pod
+sidecarContainers: {}
+  # webserver:
+  #   image: nginx
+
+# Extra volume mounts
+extraVolumeMounts: []
+  # - name: extra-volume-0
+  #   mountPath: /mnt/volume0
+  #   readOnly: true
+  #   existingClaim: volume-claim
+  # - name: extra-volume-1
+  #   mountPath: /mnt/volume1
+  #   readOnly: true
+  #   hostPath: /usr/shared/
+  # - name: extra-volume-2
+  #   mountPath: /mnt/volume2
+  #   readOnly: true
+  #   existingConfigMap: config-map
+  # - name: extra-volume-3
+  #   mountPath: /mnt/volume3
+  #   readOnly: true
+  #   existingSecret: secret-name
+
+# Include secret's content in pods environment
+secrets: false
+
+resources: {}
+#  limits:
+#    cpu: 100m
+#    memory: 32Mi
+#  requests:
+#    cpu: 50m
+#    memory: 16Mi
+
+# Node labels for pod assignment
+# ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+# Tolerations for pod assignment
+# ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+tolerations: []
+
+# Additional init containers (evaluated as template)
+# ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+extraInitContainers: []
+  # - name: initializer
+  #   image: busybox:latest
+  #   command: ['sh', '-c', 'echo initialize the app before it starts']
+
+# Enable persistence using Persistent Volume Claims
+# ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+persistence:
+  enabled: false
+  size: 200Mi
+  mountPath: /data
+  # subPath: ""
+  accessModes:
+    - ReadWriteOnce
+  finalizers:
+    - kubernetes.io/pvc-protection
+  # annotations: {}
+  # selectorLabels: {}
+  # existingClaim: ""
+  # storageClassName: default
+
+serviceMonitor:
+  # If true, a ServiceMonitor CRD is created for a prometheus operator
+  # https://github.com/coreos/prometheus-operator
+  enabled: false
+  # namespace: monitoring  (defaults to use the namespace this chart is deployed to)
+  interval: 1m
+  path: /metrics
+  scheme: http
+  tlsConfig: {}
+  labels: {}
+  scrapeTimeout: 30s
+  relabelings: []
+
+# ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+networkPolicy:
+  enabled: false
+  ingress:
+    selectors: []
+    # - namespaceSelector:
+    #     matchLabels:
+    #       name: nginx-ingress
+
+# Gatus configuration
+# ref: https://github.com/TwiN/gatus#configuration
+config:
+  endpoints:
+    - name: example
+      url: https://example.org
+      interval: 60s
+      conditions:
+        - "[STATUS] == 200"
+        - "[BODY] == pat(*<h1>Example Domain</h1>*)"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
@TwiN thank you for working on Gatus! As discussed, here is 1-1 ported https://github.com/minicloudlabs/helm-charts/tree/main/charts/gatus. 

As discussed, common lib is embedded, so there are no dependencies. It is 100% compatible with previous release version `3.4.5`, but in this PR I left chart's version 0.1.4 as we agreed.

Please let me know if there is anything else I can assist with during the migration.

P.S. I'm not sure which version you'll pick for the new release, but it probably make sense to cleanup historical records from readme (see Upgrading an existing Release to a new major version).


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
