### PR TITLE
gatus: add support for env[].valueFrom and envFrom

### DIFF
--- a/charts/gatus/Chart.yaml
+++ b/charts/gatus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gatus
 description: Automated service health dashboard
 icon: https://raw.githubusercontent.com/TwiN/gatus/a1c8422c2ff2b9d0a6f184c99e4dc728d3f2cd75/web/static/logo-192x192.png
-version: 1.0.0
+version: 1.1.0
 appVersion: v5.11.0
 type: application
 engine: gotpl

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -19,77 +19,78 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ## Configuration
 
-| Parameter                                 | Description                                     | Default                             |
-|-------------------------------------------|-------------------------------------------------|-------------------------------------|
-| `deployment.strategy`                     | Deployment strategy                             | `RollingUpdate`                     |
-| `deployment.annotateConfigChecksum`       | Restart pod when config changed                 | `true`                              |
-| `readinessProbe.enabled`                  | Enable readiness probe                          | `true`                              |
-| `livenessProbe.enabled`                   | Enable liveness probe                           | `true`                              |
-| `image.repository`                        | Image repository                                | `twinproduction/gatus`              |
-| `image.tag`                               | Overrides the Gatus image tag                   | ``                                  |
-| `image.sha`                               | Image sha                                       | ``                                  |
-| `image.pullPolicy`                        | Image pull policy                               | `IfNotPresent`                      |
-| `image.pullSecrets`                       | Image pull secrets                              | `{}`                                |
-| `hostNetwork.enabled`                     | Enable host network mode                        | `false`                             |
-| `annotations`                             | Deployment annotations                          | `{}`                                |
-| `labels`                                  | Deployment labels                               | `{}`                                |
-| `podAnnotations`                          | Pod annotations                                 | `{}`                                |
-| `podLabels`                               | Pod labels                                      | `{}`                                |
-| `extraLabels`                             | Extra labels for all manifests                  | `{}`                                |
-| `serviceAccount.create`                   | Create service account                          | `false`                             |
-| `serviceAccount.name`                     | Service account name to use                     | ``                                  |
-| `serviceAccount.annotations`              | ServiceAccount annotations                      | `{}`                                |
-| `serviceAccount.autoMount`                | Automount the service account token in the pod  | `false`                             |
-| `podSecurityContext.fsGroup`              | Pod volume's ownership GID                      | `65534`                             |
-| `securityContext.runAsNonRoot`            | Container runs as a non-root user               | `true`                              |
-| `securityContext.runAsUser`               | Container processes' UID to run the entrypoint  | `65534`                             |
-| `securityContext.runAsGroup`              | Container processes' GID to run the entrypoint  | `65534`                             |
-| `securityContext.readOnlyRootFilesystem`  | Container's root filesystem is read-only        | `true`                              |
-| `service.type`                            | Type of service                                 | `ClusterIP`                         |
-| `service.port`                            | Port for kubernetes service                     | `80`                                |
-| `service.targetPort`                      | Port for container                              | `8080`                              |
-| `service.annotations`                     | Service annotations                             | `{}`                                |
-| `service.labels`                          | Custom labels                                   | `{}`                                |
-| `ingress.enabled`                         | Enables Ingress                                 | `false`                             |
-| `ingress.ingressClassName`                | Ingress ClassName (for k8s 1.18+)               | ``                                  |
-| `ingress.name`                            | Ingress name                                    | ``                                  |
-| `ingress.annotations`                     | Ingress annotations (values are templated)      | `{}`                                |
-| `ingress.labels`                          | Custom labels                                   | `{}`                                |
-| `ingress.path`                            | Ingress accepted path                           | `/`                                 |
-| `ingress.pathType`                        | Ingress type of path                            | `Prefix`                            |
-| `ingress.extraPaths`                      | Ingress extra paths to prepend to every host    | `[]`                                |
-| `ingress.hosts`                           | Ingress accepted hostnames                      | `["chart-example.local"]`           |
-| `ingress.tls`                             | Ingress TLS configuration                       | `[]`                                |
-| `env`                                     | Extra environment variables passed to pods      | `{}`                                |
-| `sidecarContainers`                       | Sidecar containers in the pod                   | `{}`                                |
-| `extraVolumeMounts`                       | Extra volume mounts                             | `[]`                                |
-| `secrets`                                 | Include secret's content in pod environment     | `false`                             |
-| `resources`                               | CPU/Memory resource requests/limits             | `{}`                                |
-| `nodeSelector`                            | Node labels for pod assignment                  | `{}`                                |
-| `tolerations`                             | Tolerations for pod assignment                  | `[]`                                |
-| `extraInitContainers`                     | Init containers to add to the gatus pod         | `[]`                                |
-| `persistence.enabled`                     | Use persistent volume to store data             | `false`                             |
-| `persistence.size`                        | Size of persistent volume claim                 | `200Mi`                             |
-| `persistence.mounthPath`                  | Persistent data volume's mount path             | `/data`                             |
-| `persistence.subPath`                     | Mount a sub dir of the persistent volume        | `nil`                               |
-| `persistence.accessModes`                 | Persistence access modes                        | `[ReadWriteOnce]`                   |
-| `persistence.finalizers`                  | PersistentVolumeClaim finalizers                | `["kubernetes.io/pvc-protection"]`  |
-| `persistence.annotations`                 | PersistentVolumeClaim annotations               | `{}`                                |
-| `persistence.selectorLabels`              | PersistentVolumeClaim selector labels           | `{}`                                |
-| `persistence.existingClaim`               | Use an existing PVC to persist data             | `nil`                               |
-| `persistence.storageClassName`            | Type of persistent volume claim                 | `nil`                               |
-| `serviceMonitor.enabled`                  | Use servicemonitor from prometheus operator     | `false`                             |
-| `serviceMonitor.namespace`                | Namespace this servicemonitor is installed in   | ``                                  |
-| `serviceMonitor.interval`                 | How frequently Prometheus should scrape         | `1m`                                |
-| `serviceMonitor.path`                     | Path to scrape                                  | `/metrics`                          |
-| `serviceMonitor.scheme`                   | Scheme to use for metrics scraping              | `http`                              |
-| `serviceMonitor.tlsConfig`                | TLS configuration block for the endpoint        | `{}`                                |
-| `serviceMonitor.labels`                   | Labels for the servicemonitor object            | `{}`                                |
-| `serviceMonitor.scrapeTimeout`            | Timeout after which the scrape is ended         | `30s`                               |
-| `serviceMonitor.relabelings`              | RelabelConfigs for samples before ingestion     | `[]`                                |
-| `networkPolicy.enabled`                   | Enable creation of NetworkPolicy resources      | `false`                             |
-| `networkPolicy.ingress.selectors`         | List of Ingress Rule selectors                  | `[]`                                |
-| `config`                                  | [Gatus configuration][gatus-config]             | `{}`                                |
+| Parameter                                | Description                                                                                | Default                            |
+|------------------------------------------|--------------------------------------------------------------------------------------------|------------------------------------|
+| `deployment.strategy`                    | Deployment strategy                                                                        | `RollingUpdate`                    |
+| `deployment.annotateConfigChecksum`      | Restart pod when config changed                                                            | `true`                             |
+| `readinessProbe.enabled`                 | Enable readiness probe                                                                     | `true`                             |
+| `livenessProbe.enabled`                  | Enable liveness probe                                                                      | `true`                             |
+| `image.repository`                       | Image repository                                                                           | `twinproduction/gatus`             |
+| `image.tag`                              | Overrides the Gatus image tag                                                              | ``                                 |
+| `image.sha`                              | Image sha                                                                                  | ``                                 |
+| `image.pullPolicy`                       | Image pull policy                                                                          | `IfNotPresent`                     |
+| `image.pullSecrets`                      | Image pull secrets                                                                         | `{}`                               |
+| `hostNetwork.enabled`                    | Enable host network mode                                                                   | `false`                            |
+| `annotations`                            | Deployment annotations                                                                     | `{}`                               |
+| `labels`                                 | Deployment labels                                                                          | `{}`                               |
+| `podAnnotations`                         | Pod annotations                                                                            | `{}`                               |
+| `podLabels`                              | Pod labels                                                                                 | `{}`                               |
+| `extraLabels`                            | Extra labels for all manifests                                                             | `{}`                               |
+| `serviceAccount.create`                  | Create service account                                                                     | `false`                            |
+| `serviceAccount.name`                    | Service account name to use                                                                | ``                                 |
+| `serviceAccount.annotations`             | ServiceAccount annotations                                                                 | `{}`                               |
+| `serviceAccount.autoMount`               | Automount the service account token in the pod                                             | `false`                            |
+| `podSecurityContext.fsGroup`             | Pod volume's ownership GID                                                                 | `65534`                            |
+| `securityContext.runAsNonRoot`           | Container runs as a non-root user                                                          | `true`                             |
+| `securityContext.runAsUser`              | Container processes' UID to run the entrypoint                                             | `65534`                            |
+| `securityContext.runAsGroup`             | Container processes' GID to run the entrypoint                                             | `65534`                            |
+| `securityContext.readOnlyRootFilesystem` | Container's root filesystem is read-only                                                   | `true`                             |
+| `service.type`                           | Type of service                                                                            | `ClusterIP`                        |
+| `service.port`                           | Port for kubernetes service                                                                | `80`                               |
+| `service.targetPort`                     | Port for container                                                                         | `8080`                             |
+| `service.annotations`                    | Service annotations                                                                        | `{}`                               |
+| `service.labels`                         | Custom labels                                                                              | `{}`                               |
+| `ingress.enabled`                        | Enables Ingress                                                                            | `false`                            |
+| `ingress.ingressClassName`               | Ingress ClassName (for k8s 1.18+)                                                          | ``                                 |
+| `ingress.name`                           | Ingress name                                                                               | ``                                 |
+| `ingress.annotations`                    | Ingress annotations (values are templated)                                                 | `{}`                               |
+| `ingress.labels`                         | Custom labels                                                                              | `{}`                               |
+| `ingress.path`                           | Ingress accepted path                                                                      | `/`                                |
+| `ingress.pathType`                       | Ingress type of path                                                                       | `Prefix`                           |
+| `ingress.extraPaths`                     | Ingress extra paths to prepend to every host                                               | `[]`                               |
+| `ingress.hosts`                          | Ingress accepted hostnames                                                                 | `["chart-example.local"]`          |
+| `ingress.tls`                            | Ingress TLS configuration                                                                  | `[]`                               |
+| `env`                                    | Extra environment variables passed to pods                                                 | `{}`                               |
+| `envFrom`                                | Additional envFrom configuration to use a Secret or a ConfigMap in an environment variable | `[]`                               |
+| `sidecarContainers`                      | Sidecar containers in the pod                                                              | `{}`                               |
+| `extraVolumeMounts`                      | Extra volume mounts                                                                        | `[]`                               |
+| `secrets`                                | Include secret's content in pod environment                                                | `false`                            |
+| `resources`                              | CPU/Memory resource requests/limits                                                        | `{}`                               |
+| `nodeSelector`                           | Node labels for pod assignment                                                             | `{}`                               |
+| `tolerations`                            | Tolerations for pod assignment                                                             | `[]`                               |
+| `extraInitContainers`                    | Init containers to add to the gatus pod                                                    | `[]`                               |
+| `persistence.enabled`                    | Use persistent volume to store data                                                        | `false`                            |
+| `persistence.size`                       | Size of persistent volume claim                                                            | `200Mi`                            |
+| `persistence.mounthPath`                 | Persistent data volume's mount path                                                        | `/data`                            |
+| `persistence.subPath`                    | Mount a sub dir of the persistent volume                                                   | `nil`                              |
+| `persistence.accessModes`                | Persistence access modes                                                                   | `[ReadWriteOnce]`                  |
+| `persistence.finalizers`                 | PersistentVolumeClaim finalizers                                                           | `["kubernetes.io/pvc-protection"]` |
+| `persistence.annotations`                | PersistentVolumeClaim annotations                                                          | `{}`                               |
+| `persistence.selectorLabels`             | PersistentVolumeClaim selector labels                                                      | `{}`                               |
+| `persistence.existingClaim`              | Use an existing PVC to persist data                                                        | `nil`                              |
+| `persistence.storageClassName`           | Type of persistent volume claim                                                            | `nil`                              |
+| `serviceMonitor.enabled`                 | Use servicemonitor from prometheus operator                                                | `false`                            |
+| `serviceMonitor.namespace`               | Namespace this servicemonitor is installed in                                              | ``                                 |
+| `serviceMonitor.interval`                | How frequently Prometheus should scrape                                                    | `1m`                               |
+| `serviceMonitor.path`                    | Path to scrape                                                                             | `/metrics`                         |
+| `serviceMonitor.scheme`                  | Scheme to use for metrics scraping                                                         | `http`                             |
+| `serviceMonitor.tlsConfig`               | TLS configuration block for the endpoint                                                   | `{}`                               |
+| `serviceMonitor.labels`                  | Labels for the servicemonitor object                                                       | `{}`                               |
+| `serviceMonitor.scrapeTimeout`           | Timeout after which the scrape is ended                                                    | `30s`                              |
+| `serviceMonitor.relabelings`             | RelabelConfigs for samples before ingestion                                                | `[]`                               |
+| `networkPolicy.enabled`                  | Enable creation of NetworkPolicy resources                                                 | `false`                            |
+| `networkPolicy.ingress.selectors`        | List of Ingress Rule selectors                                                             | `[]`                               |
+| `config`                                 | [Gatus configuration][gatus-config]                                                        | `{}`                               |
 
 _See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)._
 

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -43,8 +43,14 @@ containers:
     {{- if .Values.env }}
     env:
     {{- range $key, $value := .Values.env }}
+    {{- if kindIs "map" $value }}
+        - name: "{{ $key }}"
+          valueFrom:
+            {{- toYaml $value.valueFrom | nindent 12 }}
+    {{- else }}
         - name: "{{ $key }}"
           value: "{{ $value }}"
+    {{- end }}
     {{- end }}
     {{- end }}
     envFrom:
@@ -53,6 +59,9 @@ containers:
       {{- if .Values.secrets }}
       - secretRef:
           name: {{ include "names.fullname" . }}
+      {{- end }}
+      {{- if .Values.envFrom }}
+      {{- toYaml .Values.envFrom | nindent 6 }}
       {{- end }}
     {{- if .Values.readinessProbe.enabled }}
     readinessProbe:

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -93,6 +93,15 @@ ingress:
 # Expects key: value
 env: {}
   # GATUS_CONFIG_PATH: config/config.yaml
+  # SECRET_VAR:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: gatus-secret
+  #       key: secret
+
+envFrom: []
+  # - secretRef:
+  #     name: gatus-secret
 
 # Sidecar containers in the pod
 sidecarContainers: {}


### PR DESCRIPTION
## Summary
This MR adds support for the env[].valueFrom syntax, allowing one to have Kubernetes Secrets made available to Gatus as environment variables.



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
