### PR TITLE
chore(gatus): bump gatus 5.18.1 -> 5.20.0

### DIFF
--- a/charts/gatus/Chart.yaml
+++ b/charts/gatus/Chart.yaml
@@ -3,7 +3,7 @@ name: gatus
 description: Automated service health dashboard
 icon: https://raw.githubusercontent.com/TwiN/gatus/a1c8422c2ff2b9d0a6f184c99e4dc728d3f2cd75/web/static/logo-192x192.png
 version: 1.3.0
-appVersion: v5.18.1
+appVersion: v5.20.0
 type: application
 engine: gotpl
 home: https://github.com/TwiN/gatus


### PR DESCRIPTION
## Summary
I'd wanted to use the homeassistant alerting, but the current gatus version (v5.18.1) provided with the last gatus helm chart release 1.3.0 doesn't have the feature yet. It was introduced with version [v5.19.0](https://github.com/TwiN/gatus/releases/tag/v5.19.0)

It is still possible to overwrite the used gatus version in the helm chart by adding this to the values.yaml
``` yaml
image:
    repository: twinproduction/gatus
    tag: v5.20.0
```

But I thought, while I'm on it, I could aswell create a pull request.

Thanks for the provided helm chart. I love using it 

## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
  - There are no relevant tests for the update 
- [x] Updated documentation in `README.md`, if applicable.
  - The used gatus version isn't mentioned in any README yet
