### PR TITLE
feat(gatus): add ability to set priorityClassName for the gatus pod

### DIFF
--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -68,6 +68,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | `resources`                              | CPU/Memory resource requests/limits                                                        | `{}`                               |
 | `nodeSelector`                           | Node labels for pod assignment                                                             | `{}`                               |
 | `tolerations`                            | Tolerations for pod assignment                                                             | `[]`                               |
+| `priorityClassName`                      | PriorityClass to be used by the gatus pod                                                  | ``                                 |
 | `extraInitContainers`                    | Init containers to add to the gatus pod                                                    | `[]`                               |
 | `persistence.enabled`                    | Use persistent volume to store data                                                        | `false`                            |
 | `persistence.size`                       | Size of persistent volume claim                                                            | `200Mi`                            |

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -94,6 +94,9 @@ containers:
         subPath: {{ .subPath | default "" }}
         readOnly: {{ .readOnly }}
     {{- end }}
+{{- if .Values.priorityClassName }}
+priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 volumes:
   - name: {{ include "names.fullname" . }}-config
     configMap:

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -147,6 +147,8 @@ nodeSelector: {}
 # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 tolerations: []
 
+priorityClassName: ""
+
 # Additional init containers (evaluated as template)
 # ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 extraInitContainers: []


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
This PR allows users to set a 'priorityClassName' to make sure Gatus has priority in the cluster over other pods.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable. Tested by deploying the helm chart with and without the priorityClassName set.
- [X] Updated documentation in `README.md`, if applicable.
